### PR TITLE
Updating MangoOS core installation version from 5.4.1 to 5.5.7

### DIFF
--- a/install-mango.sh
+++ b/install-mango.sh
@@ -153,8 +153,8 @@ if [ "$(find "$MA_HOME" -mindepth 1 -maxdepth 1)" ]; then
 fi
 
 if [ ! -f "$MA_CORE_ZIP" ] && [ -z "$MA_VERSION" ]; then
-  # MA_VERSION="$(prompt 'What version of Mango do you want to install?' '5.4.1')"
-  MA_VERSION="5.4.1"
+  # MA_VERSION="$(prompt 'What version of Mango do you want to install?' '5.5.7')"
+  MA_VERSION="5.5.7"
 fi
 
 if [ ! -f "$MA_CORE_ZIP" ] && [ -z "$MA_BUNDLE_TYPE" ]; then


### PR DESCRIPTION
Let's wait until the UDMI module v5.5.1 is available on the MangoOS store. Once it is, we'll be able to update to MangoOS core version 5.5.7.